### PR TITLE
Add poetry-plugin-export to actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install poetry
         uses: abatilo/actions-poetry@v3.0.0
       - name: Install poetry export plugin
-        run:
+        run: |
           poetry self add poetry-plugin-export
           poetry config warnings.export false
       - name: Install dependencies

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,6 +26,8 @@ jobs:
           python-version: 3.11
       - name: Install poetry
         uses: abatilo/actions-poetry@v3.0.0
+      - name: Install poetry export plugin
+        run: poetry self add poetry-plugin-export
       - name: Install dependencies
         run: poetry install
       - name: Test

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,9 @@ jobs:
       - name: Install poetry
         uses: abatilo/actions-poetry@v3.0.0
       - name: Install poetry export plugin
-        run: poetry self add poetry-plugin-export
+        run:
+          poetry self add poetry-plugin-export
+          poetry config warnings.export false
       - name: Install dependencies
         run: poetry install
       - name: Test


### PR DESCRIPTION
To resolve this warning:
"Warning: poetry-plugin-export will not be installed by default in a future version of Poetry."